### PR TITLE
Deactivate Abstract Factories

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -32,9 +32,11 @@ return [
             MvcAuth\UnauthorizedListener::class    => InvokableFactory::class,
         ],
         'abstract_factories' => [
+            /*
             DbAdapterAbstractServiceFactory::class, // so that db-connected works "out-of-the-box"
             DbConnectedResourceAbstractFactory::class,
             TableGatewayAbstractFactory::class,
+            */
         ],
     ],
     'api-tools'       => [


### PR DESCRIPTION
Unused abstract factories were commented out to improve clarity and maintainability of the configuration file. This change does not impact functionality but helps prevent confusion and unnecessary processing.