### PR TITLE
Allow laminas-http 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "^3.1",
-        "laminas/laminas-http": "^2.23",
+        "laminas/laminas-http": "^2.23 || ^3.0",
         "laminas/laminas-inputfilter": "^2.34",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48d62da61804aaf0c489e62c3ffb2b37",
+    "content-hash": "8b13efd6ef59da7b4546173a31dfac5b",
     "packages": [
         {
             "name": "brick/varexporter",


### PR DESCRIPTION
## Summary

laminas-http 3 drops the abandoned **`laminas/laminas-loader`**, replacing `Laminas\Loader\PluginClassLocator` with a self-contained `Laminas\Http\HeaderLoader`. Upstream wrote that change but never released it; [`datasage/laminas-http` 3.0.0](https://github.com/datasage/laminas-http/releases/tag/3.0.0) tags it.

## Why widen rather than move to it

Composer honours a `repositories` entry **only in the root package**, so this repository's own CI still resolves *upstream* laminas-http, which has no 3.x release. The range therefore picks 2.23.x here and nothing changes — verified, the lock still resolves 2.23.0 and the suite is unchanged.

It's the **root application**, which does carry the `repositories` entry, that can then resolve 3.0.0.

## Safe for this package

laminas-http 3's breaking changes are confined to `Headers`:

- `setPluginClassLoader()` narrows its parameter from `PluginClassLocator` to `HeaderLoader`
- `getPluginClassLoader()` gains a declared return type
- `$pluginClassLoader` changes from `protected` to `private`, which breaks subclasses

Nothing here references that API or extends `Headers` — checked across all sixteen forks plus the consuming applications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development dependency compatibility range for improved support across supported HTTP library versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
